### PR TITLE
Deps/libpact ffi 0.4.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,13 @@ jobs:
           '3.2', 
           '3.3'
           ]
+        exclude:
+          - os: ubuntu-latest
+            ruby-version: '3.0'
+          - os: macos-13
+            ruby-version: '3.0'
+          - os: macos-14
+            ruby-version: '3.0'
       fail-fast: false
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         ruby-version: [
           # '2.6',
           # '2.7', 
@@ -85,7 +85,7 @@ jobs:
         os: [
           ubuntu-latest, 
           windows-latest,
-          macos-12, 
+          macos-13, 
           macos-14
           ]
         ruby-version: [
@@ -115,7 +115,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         ruby-version: [
           # '2.6',
           # '2.7', 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ puts PactFfi.pactffi_version
   
 | OS            | Ruby          | Architecture | Supported   | Ruby Platform     |
 | -------       | -------       | ------------ | ---------   | ---------         |
-| OSX           | 2.6 - 3.3     | x86_64       | ✅          | x86_64-darwin     |
-| OSX           | 2.6 - 3.3     | aarch64 (arm)| ✅          | arm64-darwin      |
+| MacOS         | 2.6 - 3.3     | x86_64       | ✅          | x86_64-darwin     |
+| MacOS         | 2.6 - 3.3     | aarch64 (arm)| ✅          | arm64-darwin      |
 | Linux         | 2.6 - 3.3     | x86_64       | ✅          | x86_64-linux      |
 | Linux         | 2.6 - 3.3     | aarch64 (arm)| ✅          | aarch64-linux     |
 | Linux (musl)  | 2.6 - 3.3     | x86_64       | ✅          | x86_64-linux-musl |

--- a/lib/pact/ffi.rb
+++ b/lib/pact/ffi.rb
@@ -372,8 +372,7 @@ module PactFfi
                   :void
   attach_function :message_with_contents, :pactffi_message_with_contents, %i[uint32_type string pointer size_t], :void
   attach_function :message_with_metadata, :pactffi_message_with_metadata, %i[uint32_type string string], :void
-  attach_function :message_with_metadata_v2, :pactffi_message_with_metadata_v2, %i[uint32_type string string], :void
-  attach_function :with_metadata, :pactffi_with_metadata, %i[uint32_type string string int], :void
+  attach_function :with_metadata, :pactffi_with_metadata, %i[uint32_type string string int32], :bool
   attach_function :message_reify, :pactffi_message_reify, %i[uint32_type], :string
   attach_function :write_message_pact_file, :pactffi_write_message_pact_file, %i[uint16 string bool], :int32
   attach_function :with_message_pact_metadata, :pactffi_with_message_pact_metadata, %i[uint16 string string string],
@@ -408,7 +407,7 @@ module PactFfi
   attach_function :verifier_broker_source, :pactffi_verifier_broker_source, %i[pointer string string string string],
                   :void
   attach_function :verifier_broker_source_with_selectors, :pactffi_verifier_broker_source_with_selectors,
-                  %i[pointer string string string string uint8 string pointer uint16 string pointer uint16 pointer uint16], :void
+                  %i[pointer string string string string uint8 string pointer uint16 string pointer uint16 pointer uint16], :int32
   attach_function :verifier_execute, :pactffi_verifier_execute, %i[pointer], :int32
   attach_function :verifier_cli_args, :pactffi_verifier_cli_args, %i[], :string
   attach_function :verifier_logs, :pactffi_verifier_logs, %i[pointer], :string
@@ -429,13 +428,25 @@ module PactFfi
   attach_function :matches_json_value, :pactffi_matches_json_value, %i[pointer string string uint8], :string
   attach_function :pact_handle_to_pointer, :pactffi_pact_handle_to_pointer, %i[uint16], :pointer
   attach_function :handle_get_pact_spec_version, :pactffi_handle_get_pact_spec_version, %i[uint16], :int32
-  attach_function :with_multipart_file, :pactffi_with_multipart_file, %i[uint32_type int32 string string string],
-                  :pointer
   attach_function :set_header, :pactffi_set_header, %i[uint32_type int32 string string], :bool
   attach_function :with_binary_body, :pactffi_with_binary_body, %i[uint32_type int32 string pointer size_t], :bool
   attach_function :with_matching_rules, :pactffi_with_matching_rules, %i[uint32_type int32 string], :bool
   attach_function :with_multipart_file_v2, :pactffi_with_multipart_file_v2,
                   %i[uint32_type int32 string string string string], :pointer
   attach_function :message_with_metadata_v2, :pactffi_message_with_metadata_v2, %i[uint32_type string string], :void
-  attach_function :with_generators, :pactffi_with_generators, %i[uint32_type int string], :bool
+  attach_function :with_generators, :pactffi_with_generators, %i[uint32_type int32 string], :bool
+  attach_function :async_message_generate_contents, :pactffi_async_message_generate_contents, %i[pointer], :pointer
+  attach_function :message_contents_delete, :pactffi_message_contents_delete, %i[pointer], :void
+  attach_function :pact_async_message_iter_next, :pactffi_pact_async_message_iter_next, %i[pointer], :pointer
+  attach_function :pact_async_message_iter_delete, :pactffi_pact_async_message_iter_delete, %i[pointer], :void
+  attach_function :sync_message_generate_request_contents, :pactffi_sync_message_generate_request_contents,
+                  %i[pointer], :pointer
+  attach_function :sync_message_generate_response_contents, :pactffi_sync_message_generate_response_contents,
+                  %i[pointer size_t], :pointer
+  attach_function :response_status_v2, :pactffi_response_status_v2, %i[uint32_type string], :bool
+  attach_function :set_key, :pactffi_set_key, %i[uint32_type string], :bool
+  attach_function :set_pending, :pactffi_set_pending, %i[uint32_type bool], :bool
+  attach_function :set_comment, :pactffi_set_comment, %i[uint32_type string string], :bool
+  attach_function :add_text_comment, :pactffi_add_text_comment, %i[uint32_type string], :bool
+  attach_function :pact_handle_get_async_message_iter, :pactffi_pact_handle_get_async_message_iter, %i[uint16], :pointer
 end

--- a/lib/pact/ffi/async_message_pact.rb
+++ b/lib/pact/ffi/async_message_pact.rb
@@ -13,6 +13,7 @@ module PactFfi
     attach_function :new_async_message, :pactffi_async_message_new, %i[], :pointer
     attach_function :delete, :pactffi_async_message_delete, %i[pointer], :void
     attach_function :get_contents, :pactffi_async_message_get_contents, %i[pointer], :pointer
+    attach_function :generate_contents, :pactffi_async_message_generate_contents, %i[pointer], :pointer
     attach_function :get_contents_str, :pactffi_async_message_get_contents_str, %i[pointer], :string
     attach_function :set_contents_str, :pactffi_async_message_set_contents_str, %i[pointer string string], :void
     attach_function :get_contents_length, :pactffi_async_message_get_contents_length, %i[pointer], :size_t
@@ -25,5 +26,8 @@ module PactFfi
     attach_function :new, :pactffi_new_async_message, %i[uint16 string], :uint32_type
     attach_function :pact_interaction_as_asynchronous_message, :pactffi_pact_interaction_as_asynchronous_message,
                     %i[pointer], :pointer
+    attach_function :iter_next, :pactffi_pact_async_message_iter_next, %i[pointer], :pointer
+    attach_function :iter_delete, :pactffi_pact_async_message_iter_delete, %i[pointer], :void
+    attach_function :get_iter, :pactffi_pact_handle_get_async_message_iter, %i[uint16], :pointer
   end
 end

--- a/lib/pact/ffi/http_consumer.rb
+++ b/lib/pact/ffi/http_consumer.rb
@@ -29,12 +29,14 @@ module PactFfi
     attach_function :with_header, :pactffi_with_header, %i[uint32_type int32 string size_t string], :bool
     attach_function :with_header_v2, :pactffi_with_header_v2, %i[uint32_type int32 string size_t string], :bool
     attach_function :response_status, :pactffi_response_status, %i[uint32_type uint16], :bool
+    attach_function :response_status_v2, :pactffi_response_status_v2, %i[uint32_type string], :bool
     attach_function :with_body, :pactffi_with_body, %i[uint32_type int32 string string], :bool
     attach_function :with_binary_file, :pactffi_with_binary_file, %i[uint32_type int32 string pointer size_t], :bool
     attach_function :with_multipart_file, :pactffi_with_multipart_file, %i[uint32_type int32 string string string], :pointer
     attach_function :set_header, :pactffi_set_header, %i[uint32_type int32 string string], :bool
     attach_function :with_binary_body, :pactffi_with_binary_body, %i[uint32_type int32 string pointer size_t], :bool
     attach_function :with_matching_rules, :pactffi_with_matching_rules, %i[uint32_type int32 string], :bool
+    attach_function :with_generators, :pactffi_with_generators, %i[uint32_type int32 string], :bool
     attach_function :with_multipart_file_v2, :pactffi_with_multipart_file_v2, %i[uint32_type int32 string string string string], :pointer
   end
 end

--- a/lib/pact/ffi/message_consumer.rb
+++ b/lib/pact/ffi/message_consumer.rb
@@ -72,6 +72,7 @@ module PactFfi
     ]
 
     attach_function :contents_get_contents_str, :pactffi_message_contents_get_contents_str, %i[pointer], :string
+    attach_function :contents_delete, :pactffi_message_contents_delete, %i[pointer], :void
     attach_function :contents_set_contents_str, :pactffi_message_contents_set_contents_str, %i[pointer string string], :void
     attach_function :contents_get_contents_length, :pactffi_message_contents_get_contents_length, %i[pointer], :size_t
     attach_function :contents_get_contents_bin, :pactffi_message_contents_get_contents_bin, %i[pointer], :pointer

--- a/lib/pact/ffi/sync_message_consumer.rb
+++ b/lib/pact/ffi/sync_message_consumer.rb
@@ -21,6 +21,7 @@ module PactFfi
     attach_function :get_request_contents_bin, :pactffi_sync_message_get_request_contents_bin, %i[pointer], :pointer
     attach_function :set_request_contents_bin, :pactffi_sync_message_set_request_contents_bin, %i[pointer pointer size_t string], :void
     attach_function :get_request_contents, :pactffi_sync_message_get_request_contents, %i[pointer], :pointer
+    attach_function :generate_request_contents, :pactffi_sync_message_generate_request_contents, %i[pointer], :pointer
     attach_function :get_number_responses, :pactffi_sync_message_get_number_responses, %i[pointer], :size_t
     attach_function :get_response_contents_str, :pactffi_sync_message_get_response_contents_str, %i[pointer size_t], :string
     attach_function :set_response_contents_str, :pactffi_sync_message_set_response_contents_str, %i[pointer size_t string string], :void
@@ -33,6 +34,6 @@ module PactFfi
     attach_function :get_provider_state, :pactffi_sync_message_get_provider_state, %i[pointer uint32_type], :pointer
     attach_function :get_provider_state_iter, :pactffi_sync_message_get_provider_state_iter, %i[pointer], :pointer
     attach_function :new_interaction, :pactffi_new_sync_message_interaction, %i[uint16 string], :uint32_type
-    attach_function :pact_handle_get_sync_message_iter, :pactffi_pact_handle_get_sync_message_iter, %i[uint16], :pointer
+    attach_function :get_iter, :pactffi_pact_handle_get_sync_message_iter, %i[uint16], :pointer
   end
 end

--- a/lib/pact/ffi/utils.rb
+++ b/lib/pact/ffi/utils.rb
@@ -146,5 +146,6 @@ module PactFfi
     attach_function :matches_json_value, :pactffi_matches_json_value, %i[pointer string string uint8], :string
     attach_function :pact_handle_to_pointer, :pactffi_pact_handle_to_pointer, %i[uint16], :pointer
     attach_function :handle_get_pact_spec_version, :pactffi_handle_get_pact_spec_version, %i[uint16], :int32
+    attach_function :with_metadata, :pactffi_with_metadata, %i[uint32_type string string int32], :bool
   end
 end

--- a/lib/pact/ffi/verifier.rb
+++ b/lib/pact/ffi/verifier.rb
@@ -51,7 +51,7 @@ module PactFfi
     attach_function :url_source, :pactffi_verifier_url_source, %i[pointer string string string string], :void
     attach_function :broker_source, :pactffi_verifier_broker_source, %i[pointer string string string string], :void
     attach_function :broker_source_with_selectors, :pactffi_verifier_broker_source_with_selectors,
-                    %i[pointer string string string string uint8 string pointer uint16 string pointer uint16 pointer uint16], :void
+                    %i[pointer string string string string uint8 string pointer uint16 string pointer uint16 pointer uint16], :int32
     attach_function :execute, :pactffi_verifier_execute, %i[pointer], :int32
     attach_function :cli_args, :pactffi_verifier_cli_args, %i[], :string
     attach_function :logs, :pactffi_verifier_logs, %i[pointer], :string

--- a/lib/pact/ffi/version.rb
+++ b/lib/pact/ffi/version.rb
@@ -1,5 +1,5 @@
 module Pact
   module Version
-    VERSION = '0.4.22.2'
+    VERSION = '0.4.26.0'
   end
 end

--- a/script/lib/download-plugin-cli.sh
+++ b/script/lib/download-plugin-cli.sh
@@ -73,13 +73,13 @@ echo detected_os = $detected_os
 case ${detected_os} in
 'Darwin arm64')
     echo "downloading of osx aarch64 plugin cli"
-    os='osx-aarch64'
-    download_plugin_cli "osx-aarch64.gz" "" "pact-plugin-cli.gz" "${os}"
+    os='macos-aarch64'
+    download_plugin_cli "macos-aarch64.gz" "" "pact-plugin-cli.gz" "${os}"
     ;;
 'Darwin x86' | 'Darwin x86_64' | "Darwin"*)
     echo "downloading of osx x86_64 plugin cli"
-    os='osx-x86_64'
-    download_plugin_cli "osx-x86_64.gz" "" "pact-plugin-cli.gz" "${os}"
+    os='macos-x86_64'
+    download_plugin_cli "macos-x86_64.gz" "" "pact-plugin-cli.gz" "${os}"
     ;;
 "Linux aarch64"* | "Linux arm64"*)
     echo "downloading of linux aarch64 plugin cli"

--- a/script/lib/download-verifier-cli.sh
+++ b/script/lib/download-verifier-cli.sh
@@ -73,13 +73,13 @@ echo detected_os = $detected_os
 case ${detected_os} in
 'Darwin arm64')
     echo "downloading of osx aarch64 verifier cli"
-    os='osx-aarch64'
-    download_verifier_cli "osx-aarch64.gz" "" "pact_verifier_cli.gz" "${os}"
+    os='macos-aarch64'
+    download_verifier_cli "macos-aarch64.gz" "" "pact_verifier_cli.gz" "${os}"
     ;;
 'Darwin x86' | 'Darwin x86_64' | "Darwin"*)
     echo "downloading of osx x86_64 verifier cli"
-    os='osx-x86_64'
-    download_verifier_cli "osx-x86_64.gz" "" "pact_verifier_cli.gz" "${os}"
+    os='macos-x86_64'
+    download_verifier_cli "macos-x86_64.gz" "" "pact_verifier_cli.gz" "${os}"
     ;;
 "Linux aarch64"* | "Linux arm64"*)
     echo "downloading of linux aarch64 verifier cli"

--- a/script/lib/export-binary-versions.sh
+++ b/script/lib/export-binary-versions.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -eu
 LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the script is running
 PROJECT_DIR="${LIB_DIR}"/../../
-export FFI_VERSION=v0.4.22
-export STANDALONE_VERSION=2.4.3
-export PLUGIN_CLI_VERSION=v0.1.2
-export VERIFIER_CLI_VERSION=v1.1.2
+export FFI_VERSION=v0.4.26
+export STANDALONE_VERSION=2.4.20
+export PLUGIN_CLI_VERSION=v0.1.3
+export VERIFIER_CLI_VERSION=v1.1.4
 # export STANDALONE_VERSION=$(grep "PACT_STANDALONE_VERSION = '" "$PROJECT_DIR"/standalone/install.ts | grep -E -o "'(.*)'" | cut -d"'" -f2)
 # export FFI_VERSION=v$(grep "PACT_FFI_VERSION = '" "$PROJECT_DIR"/src/ffi/index.ts | grep -E -o "'(.*)'" | cut -d"'" -f2)


### PR DESCRIPTION
- Update libpact_ffi to 0.4.26
- Add in new functions, autogenned via https://github.com/YOU54F/deno-ffigen/blob/rubyffi_gen/examples/pact/lib/symbols.ts
- Update macOS 12 runners to 13
- Skip grpc tests on macOS / linux, ruby 3.0 as bundler version is too old. Fails currently on master, so failures not introduced by this change