### PR TITLE
Deps/pact ffi 0.5.6

### DIFF
--- a/lib/pact/ffi.rb
+++ b/lib/pact/ffi.rb
@@ -412,6 +412,7 @@ module PactFfi
   attach_function :verifier_json, :pactffi_verifier_json, %i[pointer], :string
   attach_function :verifier_set_follow_redirects, :pactffi_verifier_set_follow_redirects, %i[pointer uint8], :void
   attach_function :using_plugin, :pactffi_using_plugin, %i[uint16 string string], :uint32_type
+  attach_function :using_plugin_with_delay, :pactffi_using_plugin_with_delay, %i[uint16 string string ulong_long], :uint32_t
   attach_function :cleanup_plugins, :pactffi_cleanup_plugins, %i[uint16], :void
   attach_function :interaction_contents, :pactffi_interaction_contents, %i[uint32_type int32 string string],
                   :uint32_type
@@ -446,4 +447,8 @@ module PactFfi
   attach_function :set_comment, :pactffi_set_comment, %i[uint32_type string string], :bool
   attach_function :add_text_comment, :pactffi_add_text_comment, %i[uint32_type string], :bool
   attach_function :pact_handle_get_async_message_iter, :pactffi_pact_handle_get_async_message_iter, %i[uint16], :pointer
+  attach_function :add_interaction_reference, :pactffi_add_interaction_reference, %i[uint32_type string string string], :bool
+  attach_function :set_test_run_id, :pactffi_set_test_run_id, %i[string], :void
+  attach_function :register_plugin_log_callback, :pactffi_register_plugin_log_callback, %i[pointer], :void
+  attach_function :get_plugin_logs, :pactffi_get_plugin_logs, %i[string], :string
 end

--- a/lib/pact/ffi.rb
+++ b/lib/pact/ffi.rb
@@ -412,7 +412,7 @@ module PactFfi
   attach_function :verifier_json, :pactffi_verifier_json, %i[pointer], :string
   attach_function :verifier_set_follow_redirects, :pactffi_verifier_set_follow_redirects, %i[pointer uint8], :void
   attach_function :using_plugin, :pactffi_using_plugin, %i[uint16 string string], :uint32_type
-  attach_function :using_plugin_with_delay, :pactffi_using_plugin_with_delay, %i[uint16 string string ulong_long], :uint32_t
+  attach_function :using_plugin_with_delay, :pactffi_using_plugin_with_delay, %i[uint16 string string ulong_long], :uint32_type
   attach_function :cleanup_plugins, :pactffi_cleanup_plugins, %i[uint16], :void
   attach_function :interaction_contents, :pactffi_interaction_contents, %i[uint32_type int32 string string],
                   :uint32_type

--- a/lib/pact/ffi/async_message_pact.rb
+++ b/lib/pact/ffi/async_message_pact.rb
@@ -29,5 +29,6 @@ module PactFfi
     attach_function :iter_next, :pactffi_pact_async_message_iter_next, %i[pointer], :pointer
     attach_function :iter_delete, :pactffi_pact_async_message_iter_delete, %i[pointer], :void
     attach_function :get_iter, :pactffi_pact_handle_get_async_message_iter, %i[uint16], :pointer
+    attach_function :add_interaction_reference, :pactffi_add_interaction_reference, %i[uint32_type string string string], :bool
   end
 end

--- a/lib/pact/ffi/message_consumer.rb
+++ b/lib/pact/ffi/message_consumer.rb
@@ -126,5 +126,6 @@ module PactFfi
     attach_function :free_handle, :pactffi_free_message_pact_handle, %i[uint16], :uint32_type
     attach_function :pact_handle_get_message_iter, :pactffi_pact_handle_get_message_iter, %i[uint16], :pointer
     attach_function :with_metadata_v2, :pactffi_message_with_metadata_v2, %i[uint32_type string string], :void
+    attach_function :add_interaction_reference, :pactffi_add_interaction_reference, %i[uint32_type string string string], :bool
   end
 end

--- a/lib/pact/ffi/plugin_consumer.rb
+++ b/lib/pact/ffi/plugin_consumer.rb
@@ -33,8 +33,12 @@ module PactFfi
     ]
 
     attach_function :using_plugin, :pactffi_using_plugin, %i[uint16 string string], :uint32_type
+    attach_function :using_plugin_with_delay, :pactffi_using_plugin_with_delay, %i[uint16 string string ulong_long], :uint32_t
     attach_function :cleanup_plugins, :pactffi_cleanup_plugins, %i[uint16], :void
     attach_function :interaction_contents, :pactffi_interaction_contents, %i[uint32_type int32 string string],
                     :uint32_type
+    attach_function :add_interaction_reference, :pactffi_add_interaction_reference, %i[uint32_type string string string], :bool
+    attach_function :register_plugin_log_callback, :pactffi_register_plugin_log_callback, %i[pointer], :void
+    attach_function :get_plugin_logs, :pactffi_get_plugin_logs, %i[string], :string
   end
 end

--- a/lib/pact/ffi/plugin_consumer.rb
+++ b/lib/pact/ffi/plugin_consumer.rb
@@ -33,7 +33,7 @@ module PactFfi
     ]
 
     attach_function :using_plugin, :pactffi_using_plugin, %i[uint16 string string], :uint32_type
-    attach_function :using_plugin_with_delay, :pactffi_using_plugin_with_delay, %i[uint16 string string ulong_long], :uint32_t
+    attach_function :using_plugin_with_delay, :pactffi_using_plugin_with_delay, %i[uint16 string string ulong_long], :uint32_type
     attach_function :cleanup_plugins, :pactffi_cleanup_plugins, %i[uint16], :void
     attach_function :interaction_contents, :pactffi_interaction_contents, %i[uint32_type int32 string string],
                     :uint32_type

--- a/lib/pact/ffi/sync_http_consumer.rb
+++ b/lib/pact/ffi/sync_http_consumer.rb
@@ -32,5 +32,6 @@ module PactFfi
     attach_function :iter_next, :pactffi_pact_sync_http_iter_next, %i[pointer], :pointer
     attach_function :iter_delete, :pactffi_pact_sync_http_iter_delete, %i[pointer], :void
     attach_function :pact_handle_get_sync_http_iter, :pactffi_pact_handle_get_sync_http_iter, %i[uint16], :pointer
+    attach_function :add_interaction_reference, :pactffi_add_interaction_reference, %i[uint32_type string string string], :bool
   end
 end

--- a/lib/pact/ffi/sync_message_consumer.rb
+++ b/lib/pact/ffi/sync_message_consumer.rb
@@ -35,5 +35,6 @@ module PactFfi
     attach_function :get_provider_state_iter, :pactffi_sync_message_get_provider_state_iter, %i[pointer], :pointer
     attach_function :new_interaction, :pactffi_new_sync_message_interaction, %i[uint16 string], :uint32_type
     attach_function :get_iter, :pactffi_pact_handle_get_sync_message_iter, %i[uint16], :pointer
+    attach_function :add_interaction_reference, :pactffi_add_interaction_reference, %i[uint32_type string string string], :bool
   end
 end

--- a/lib/pact/ffi/version.rb
+++ b/lib/pact/ffi/version.rb
@@ -1,5 +1,5 @@
 module Pact
   module Version
-    VERSION = '0.5.5.0'
+    VERSION = '0.5.6.0'
   end
 end

--- a/lib/pact/ffi/version.rb
+++ b/lib/pact/ffi/version.rb
@@ -1,5 +1,5 @@
 module Pact
   module Version
-    VERSION = '0.5.4.0'
+    VERSION = '0.5.5.0'
   end
 end


### PR DESCRIPTION
updates pact-ffi to 0.5.6

wires up new funcs

add_interaction_reference across all builders
plugins - using_plugin_with_delay / register_plugin_log_callback / get_plugin_logs
main ffi - set_test_run_id